### PR TITLE
Fix production mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "This component contains an option to select an input file form which metadata needs to be extracted, an option to search from available mapping schemas whose name will be self explainatory .",
   "author": "Ajay",
   "license": "Apache License 2.0",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": false,
   "keywords": [
     "metadata",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@types/typeahead": "^0.11.32",
     "@typescript-eslint/eslint-plugin": "^5.52.0",
     "eslint": "^8.34.0",
     "eslint-config-prettier": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,16 @@
   },
   "type": "module",
   "main": "./dist/com_mapping-service-input.umd.js",
+  "module": "./dist/com_mapping-service-input.es.js",
+  "exports": {
+    ".": {
+      "import": "./dist/com_mapping-service-input.es.js",
+      "require": "./dist/com_mapping-service-input.umd.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "dev": "vite",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "eslint-plugin-n": "^15.6.1",
     "eslint-plugin-promise": "^6.1.1",
     "prettier": "2.8.4",
-    "typescript": "^4.9.5",
-    "vite": "^4.1.1"
+    "typescript": "^5.0.2",
+    "vite": "^4.3.5"
   },
   "dependencies": {
     "filepond": "^4.30.4",

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import typeaheadCSS from "typeahead-standalone/dist/basic.css?inline";
 import customCSS from './style.css?inline';
 
 const ATTRIBUTES: string[] = ["base-url"];
-export class MappingInputProvider extends HTMLElement {
+class MappingInputProvider extends HTMLElement {
   shadowRoot: ShadowRoot;
   private testingFileChooser: FilePond | null = null;
   // --- Attribute accessible from the HTML tag:

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,16 +7,15 @@ import { Dictionary, typeaheadResult } from "typeahead-standalone/dist/types";
 import typeaheadCSS from "typeahead-standalone/dist/basic.css?inline";
 import customCSS from './style.css?inline';
 
-const ATTRIBUTES: string[] = ["base-url"
-];
+const ATTRIBUTES: string[] = ["base-url"];
 export class MappingInputProvider extends HTMLElement {
   shadowRoot: ShadowRoot;
   private testingFileChooser: FilePond | null = null;
   private mappingchooser: typeaheadResult<Dictionary> | null = null;
   // --- Attribute accessible from the HTML tag:
   baseUrl: URL = new URL("http://localhost:8090/");
-
   // ---
+
 
   // --- Helper methods
   addCssContent(css: string): void {
@@ -44,12 +43,10 @@ export class MappingInputProvider extends HTMLElement {
     this.addCssContent(typeaheadCSS);
     this.addCssContent(customCSS);
 
-    {
-      // Apply HTML Template to shadow DOM
-      const template = document.createElement("template");
-      template.innerHTML = templateContent;
-      this.shadowRoot.append(template.content.cloneNode(true));
-    }
+    // Apply HTML Template to shadow DOM
+    const template = document.createElement("template");
+    template.innerHTML = templateContent;
+    this.shadowRoot.append(template.content.cloneNode(true));
   }
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@ import * as FilePondLib from "filepond";
 import { FilePond, FilePondOptions } from "filepond";
 import filepondCSS from "filepond/dist/filepond.min.css?inline";
 import typeahead from "typeahead-standalone";
-import { Dictionary, typeaheadResult } from "typeahead-standalone/dist/types";
 import typeaheadCSS from "typeahead-standalone/dist/basic.css?inline";
 import customCSS from './style.css?inline';
 
@@ -11,7 +10,6 @@ const ATTRIBUTES: string[] = ["base-url"];
 export class MappingInputProvider extends HTMLElement {
   shadowRoot: ShadowRoot;
   private testingFileChooser: FilePond | null = null;
-  private mappingchooser: typeaheadResult<Dictionary> | null = null;
   // --- Attribute accessible from the HTML tag:
   baseUrl: URL = new URL("http://localhost:8090/");
   // ---
@@ -92,7 +90,7 @@ export class MappingInputProvider extends HTMLElement {
       this.shadowRoot.getElementById("mappingchooser")
     );
     if (inputElement != null) {
-      this.mappingchooser = typeahead({
+      typeahead({
         input: inputElement,
         minLength: -1,
         highlight: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -194,9 +194,9 @@ export class MappingInputProvider extends HTMLElement {
     element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(JSON.stringify(response)));
     element.setAttribute('download', "result.json");
     element.style.display = 'none';
-    this.shadowRoot.appendChild;
+    this.shadowRoot.appendChild(element);
     element.click();
-    this.shadowRoot.removeChild;
+    this.shadowRoot.removeChild(element);
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import filepondCSS from "filepond/dist/filepond.min.css?inline";
 import typeahead from "typeahead-standalone";
 import { Dictionary, typeaheadResult } from "typeahead-standalone/dist/types";
 import typeaheadCSS from "typeahead-standalone/dist/basic.css?inline";
+import customCSS from './style.css?inline';
 
 const ATTRIBUTES: string[] = ["base-url"
 ];
@@ -41,6 +42,7 @@ export class MappingInputProvider extends HTMLElement {
     this.shadowRoot = this.attachShadow({ mode: "open" });
     this.addCssContent(filepondCSS);
     this.addCssContent(typeaheadCSS);
+    this.addCssContent(customCSS);
 
     {
       // Apply HTML Template to shadow DOM

--- a/src/main.ts
+++ b/src/main.ts
@@ -148,9 +148,8 @@ export class MappingInputProvider extends HTMLElement {
       this.baseUrl = newValue;
       this.connectedCallback();
     }
-    this.testingFileChooser;
-    this.mappingchooser;
   }
+
   /**
    * Optional boolean parameter download used in executeMapping method, user can choose to download the result.
    * It will help user chose between true, false or no parameter
@@ -186,6 +185,7 @@ export class MappingInputProvider extends HTMLElement {
       }
     }
   }
+
   /**
    * In case if download is required triggerDownload can be used
    */

--- a/src/template.html
+++ b/src/template.html
@@ -1,4 +1,3 @@
-<link rel="stylesheet" href="src/style.css">
 <div class="mapping-container">
 	<h2 class="mapping-title">Choose a Mapping</h2>
 	<div class="mapping-input-container">


### PR DESCRIPTION
Work in progress.

After quite some fiddling, I am pretty sure the error occurs in code generated by vite when trying to import typeahead. If you remote typeahead from the main.rs, it works (it does not throw errors, of course functionality is limited then). Not sure why, though.

- Maybe the import statement has to be different? I did not find a verbose vite documentation on details, though. Only some special things like ?inline and ?raw.
  - I produced am minimal example which already breaks:
  
    ```
    import typeahead from "typeahead-standalone";
    
    function hello() {
      console.log("hello");
      typeahead;
    }
    ```
- Maybe switching to webpack could solve the issue?

The commits here are mostly cleanup which happened while fiddling around, so far.

**debugging strategy**

- setting `minify: false` in vite.config.json
- using `npm preview` will serve the files under e.g. `http://localhost:4173/com_mapping-service-input.umd.js` making it easier to debug the current local version (simply do `<script src="http://localhost:4173/com_mapping-service-input.umd.js"></script>` in the frontend file).
- I used `python3 -m http.server 8040` to serve the frontend without npm